### PR TITLE
Make RGB backlight optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # Ignore compiled files
 /target
 **/target
+/Cargo.lock


### PR DESCRIPTION
Waveshare has two LCD1602 displays: the RGB module which this crate targeted and the [I2C module](https://www.waveshare.com/wiki/LCD1602_I2C_Module) which uses the same character chip, but doesn't have the RGB backlight.

This PR makes the `rgb_address` optional in the constructor.  It's not a particularly nice change because `set_rgb` silently does nothing if `rgb_address = None`.  That said, I think it's the minimal change in terms of lines of code.
